### PR TITLE
feat: make GNOROOT configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Gno language support for NeoVim.
 
 * `:GnoDoc` - Show documentation for a package. Optional second argument is package name.
 * `:GnoFmt` - Format current file.
+* `:GnoRoot` - Print current gnoroot.
 * `:GnoTest` - Run unit test.
-    * `:GnoTest` - Test current directory or unit test file (if currently open).
+    * `:GnoTest` - Test current unit test file or package.
     * `:GnoTest ./package` - Test a specific directory.
 
 ## Prerequisites
@@ -66,22 +67,65 @@ Plug 'x1unix/gno.nvim'
 Here is a configuration example with defaults:
 
 > [!NOTE]
-> Please check https://neovim.io/doc/user/lsp.html#vim.lsp.config()
+> For LSP config, please check https://neovim.io/doc/user/lsp.html#vim.lsp.config()
 
 ```lua
 require('gno-nvim').setup({
-    -- Path to gnopls server binary.
-    cmd = { 'gnopls', 'serve' },
+    -- Custom GNOROOT path. Can be string or function.
+    --
+    -- Passed into Gno commands and LSP server environment variable.
+    --gnoroot = function()
+    --    return os.getenv("GNOROOT")
+    --end,
 
-    -- Custom environment variables.
-    cmd_env = {
-       -- GNOROOT: 'your custom GNOROOT path', 
+    -- LSP client config
+    lsp = {
+        -- Path to gnopls server binary.
+        cmd = { 'gnopls', 'serve' },
+
+        -- Custom environment variables.
+        cmd_env = {
+           -- GNOROOT: 'custom env variable', 
+        },
+
+        -- By default - integrate with nvim-cmp if installed.
+        capabilities = require('cmp_nvim_lsp').default_capabilities()
+
+        filetypes = { 'gno' },
+        -- ...
     },
-
-    -- By default - integrate with nvim-cmp if installed.
-    capabilities = require('cmp_nvim_lsp').default_capabilities()
-
-    filetypes = { 'gno' },
-    -- ...
 })
 ```
+
+### Project-Specific GNOROOT
+
+GNOROOT can be configured dynamically per-project.
+
+> [!NOTE]
+> GNOROOT for language server is set only once during LSP session startup.
+
+Use `:GnoRoot` command to get current `GNOROOT`.
+
+```lua
+local utils = require("gno-nvim.utils")
+
+local gno_fork_path = os.getenv("HOME") .. "/work/gno"
+
+require('gno-nvim').setup({
+  gnoroot = function ()
+    local cwd = vim.fn.expand("%:p:h")
+    if cwd == "" then
+      cwd = vim.fn.getcwd()
+    end
+
+    -- If inside Gno work repo, use it as a GNOROOT.
+    if utils.has_prefix(cwd, gno_fork_path) then
+      return gno_fork_path
+    end
+
+    -- Use defaults
+    return nil
+  end,
+})
+```
+

--- a/lua/gno-nvim/utils.lua
+++ b/lua/gno-nvim/utils.lua
@@ -27,25 +27,49 @@ function M.get_gnoroot()
     return ""
   end
 
-  gnoroot = vim.fn.system(gno_bin .. "env GNOROOT")
+  gnoroot = vim.fn.system(gno_bin .. " env GNOROOT")
   gnoroot = vim.trim(gnoroot)
   return gnoroot
 end
 
-local function has_suffix(str, suffix)
+--- If value is a function - returns function result.
+--- Otherwise, returns a value.
+---@generic T
+---@param val T | fun(): T
+function M.unwrap_lazy(val)
+  if type(val) == "function" then
+    return val()
+  else
+    return val
+  end
+end
+
+--- Checks whether string has a prefix
+--- @param str string
+--- @param prefix string
+--- @return boolean
+function M.has_prefix(str, prefix)
+    return str:sub(1, #prefix) == prefix
+end
+
+--- Checks whether string has a suffix
+--- @param str string
+--- @param suffix string
+--- @return boolean
+function M.has_suffix(str, suffix)
     return suffix == "" or str:sub(-#suffix) == suffix
 end
 
 --- Checks whether file path corresponds to a Gno golden test file.
 --- @return boolean
 function M.is_golden_test_file(fname)
-  return has_suffix(fname, "_filetest.gno")
+  return M.has_suffix(fname, "_filetest.gno")
 end
 
 --- Checks whether file path corresponds to a Gno unit test file.
 --- @return boolean
 function M.is_unit_test_file(fname)
-  return has_suffix(fname, "_test.gno")
+  return M.has_suffix(fname, "_test.gno")
 end
 
 local function find_buf_by_name(name)


### PR DESCRIPTION
Introduce support of dynamic per-project `GNOROOT`.

Value is passed as environment variable for gnopls and as `-root-dir` argument for `gno` commands.